### PR TITLE
Bump rbtree version to 0.4.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,6 @@ gem 'ruby-prof', platforms: [:ruby_22, :ruby_23, :ruby_24]
 
 gem 'rake', '>= 12.3', '< 14.0'
 gem 'metric_fu', github: 'metricfu/metric_fu', branch: 'main'
+gem 'rbtree', '~> 0.4.6'
 
 gemspec


### PR DESCRIPTION
I suppose that bumping `rbtree` to 0.4.6 will solve theproblem discussed [here](https://popmenu.slack.com/archives/GEUUP1E5C/p1713888431815399)
Additional gems which were updated after running `bin/install` on `popmenu`
```
serverengine (2.3.0) --> serverengine (2.3.2)
sigdump (0.2.4) --> sigdump (0.2.5)
bunny (2.19.0) --> bunny (2.22.0)
```